### PR TITLE
Fixed failing command line args

### DIFF
--- a/SQLCC.Core/Interfaces/IDbProvider.cs
+++ b/SQLCC.Core/Interfaces/IDbProvider.cs
@@ -3,16 +3,18 @@ using SQLCC.Core.Objects;
 
 namespace SQLCC.Core.Interfaces
 {
-   internal interface IDbProvider : IExtension
-   {
-      void StartTrace(string traceName);
+	public interface IDbProvider : IExtension
+	{
+		void StartTrace(string traceName);
 
-      void StopTrace(string traceName);
+		void StopTrace(string traceName);
 
-      bool IsTraceRunning(string traceName);
+		string GetLastTraceName();
 
-      List<DbCodeSegment> GetTraceCodeSegments(string traceName);
+		bool IsTraceRunning(string traceName);
 
-      List<DbObject> GetAllObjects();
-   }
+		List<DbCodeSegment> GetTraceCodeSegments(string traceName);
+
+		List<DbObject> GetAllObjects();
+	}
 }

--- a/SQLCC.Tests/Properties/AssemblyInfo.cs
+++ b/SQLCC.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SQLCC.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SQLCC.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d065a58d-768c-41ea-a665-dfeffded09c7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SQLCC.Tests/SQLCC.Tests.csproj
+++ b/SQLCC.Tests/SQLCC.Tests.csproj
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{80887635-8FAC-40F4-BAC4-058B0958E27F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SQLCC.Tests</RootNamespace>
+    <AssemblyName>SQLCC.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NSubstitute">
+      <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="TestArgumentProvider.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SQLCC.Core\SQLCC.Core.csproj">
+      <Project>{8D51B0CA-E25C-430F-A3CD-4A4AFEB433E4}</Project>
+      <Name>SQLCC.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SQLCC\SQLCC.csproj">
+      <Project>{65d62576-596b-4982-aa92-250df043b1ee}</Project>
+      <Name>SQLCC</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/SQLCC.Tests/TestArgumentProvider.cs
+++ b/SQLCC.Tests/TestArgumentProvider.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using SQLCC.Core.Interfaces;
+using SQLCC.Core.Objects;
+
+namespace SQLCC.Tests
+{
+	[TestClass]
+	public class TestArgumentProvider
+	{
+		[TestMethod]
+		public void GetTraceName_GivenEmptyTraceNameArgAndStartCommand_ShouldReturnDateTimetracename()
+		{
+			var startTime = DateTime.Now.ToString("yyyyMMddHHmmss");
+			
+			var traceName = ArgumentProvider.GetTraceName(new Dictionary<string, string>(), "start", null);
+			
+			var endTime = DateTime.Now.ToString("yyyyMMddHHmmss");
+
+			Assert.IsTrue(String.CompareOrdinal(startTime, traceName) <= 0);
+			Assert.IsTrue(String.CompareOrdinal(endTime, traceName) >= 0);
+		}
+
+		[TestMethod]
+		public void GetTraceName_GivenTraceNameArg_ShouldReturnTracename()
+		{
+			const string expectedTraceName = "TestTrace1";
+			var arguments = new Dictionary<string, string> { { "app.traceName", expectedTraceName } };
+
+			var traceName = ArgumentProvider.GetTraceName(arguments, "start", null);
+
+			Assert.AreEqual(expectedTraceName, traceName);
+		}
+
+		[TestMethod]
+		public void GetTraceName_GivenEmptyTraceNameArgAndNotStartCommand_WithSQLCCPrefix_ShouldStripPrefixFromLastTraceName()
+		{
+			const string lastTraceName = "SQLCC_TestTrace1";
+			const string expectedTraceName = "TestTrace1";
+			var dbProvider = Substitute.For<IDbProvider>();
+			dbProvider.GetLastTraceName().Returns(lastTraceName);
+			var arguments = new Dictionary<string, string>();
+
+			var traceName = ArgumentProvider.GetTraceName(arguments, "notStart", dbProvider);
+
+			Assert.AreEqual(expectedTraceName, traceName);
+		}
+	}
+	
+}

--- a/SQLCC.Tests/packages.config
+++ b/SQLCC.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NSubstitute" version="1.6.1.0" targetFramework="net45" />
+</packages>

--- a/SQLCC.sln
+++ b/SQLCC.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLCC.Tests", "SQLCC.Tests\SQLCC.Tests.csproj", "{80887635-8FAC-40F4-BAC4-058B0958E27F}"
+EndProject
 Global
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = SQLCC.vsmdi
@@ -69,6 +71,16 @@ Global
 		{B07A4B41-E8EB-41CC-98E6-2A8D042EEB5D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{B07A4B41-E8EB-41CC-98E6-2A8D042EEB5D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B07A4B41-E8EB-41CC-98E6-2A8D042EEB5D}.Release|x86.ActiveCfg = Release|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{80887635-8FAC-40F4-BAC4-058B0958E27F}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SQLCC/ArgumentProvider.cs
+++ b/SQLCC/ArgumentProvider.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using SQLCC.Core.Interfaces;
+
+static public class ArgumentProvider
+{
+	public static string GetTraceName(IDictionary<string, string> arguments, string command, IDbProvider dbProvider)
+	{
+		// Get trace name from provided, last trace, or generate one.
+		string traceName;
+		arguments.TryGetValue("app.traceName", out traceName);
+		if (traceName == null && command != "start")
+		{
+			traceName = dbProvider.GetLastTraceName().Substring(6);
+		}
+		else if (traceName == null && command == "start")
+		{
+			traceName = DateTime.Now.ToString("yyyyMMddHHmmss");
+		}
+		return traceName;
+	}
+}

--- a/SQLCC/SQLCC.csproj
+++ b/SQLCC/SQLCC.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArgumentProvider.cs" />
     <Compile Include="CodeCoverageProcessor.cs" />
     <Compile Include="AssemblyLoader.cs" />
     <Compile Include="Commands\GenerateOutputCommand.cs" />

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<repositories>
+  <repository path="..\SQLCC.Tests\packages.config" />
+</repositories>


### PR DESCRIPTION
Fixed parsing command line args to not error for empty app.traceName and app.command.
