### PR TITLE
Update format.scrub

### DIFF
--- a/SQLCC/format.scrub
+++ b/SQLCC/format.scrub
@@ -1,11 +1,11 @@
-﻿{1}([\s]+){0}	$1	Eliminate extranious white-space
+{1}([\s]+){0}	$1	Eliminate extranious white-space
 (^[\s]*--[\s\S]+)([\n\r]+[\s]*CREATE[\s]+(PROCEDURE|FUNCTION|TRIGGER))	{0}$1{1}$2	Beginning create statement
 ([\s]*CREATE[\s]+(PROCEDURE|FUNCTION|TRIGGER)[\s]+[\s\S]+([\s]+AS[\s]+BEGIN[\s]+))	{0}$1{1}	Beginning create statement
 ([\s]*END(;)*[\s]*\z)	{0}$1{1}	Last end statement.
 ([\s]*BEGIN[\s]*)({0})	$2$1	If there is a BEGIN statement near the start of coverage, include BEGIN.
 ({1})([\s]*END[\s]*)	$2$1	If there is an END statement near the end of coverage, include END.
-{1}([\s]*(--.*)*[\s]*(begin|end)*[\s]*(--.*)*[\s]*){0}	$1	Include begin/end if it is surrounded by comments or just white-space.  Also include comments.
-(end)([\s]*(--.*)*[\s]*){0}	$1{0}$2	Cover up until end statement.
+{1}([\s]*(--).*[\s]*(begin|end)*[\s]*(--).*[\s]*){0}	$1	Include begin/end if it is surrounded by comments or just white-space.  Also include comments.
+(end)([\s]*(--).*[\s]*){0}	$1{0}$2	Cover up until end statement.
 (([\s]*ELSE[\s]*)[\s]*(--.*)*[\s]*){0}	{0}$1	If there is an ELSE statemenet that was hit, cover this as well.
 {1}([\s]*(declare[\s]+.+)+[\n\r]+([\s]*declare[\s]+.+)*[\s]*)	$1{1}	DECLARE statements are not covered since profiler does not capture them if there is no default value.
 ([\s]*(declare[\s]+.+)+[\n\r]+([\s]*declare[\s]+.+)*[\s]*){0}	{0}$1	DECLARE statements are not covered since profiler does not capture them if there is no default value.


### PR DESCRIPTION
Updating regular expressions to avoid exponential processing time for some cases. If DB object definition contains line of dashes "-------------", the program does not finish processing and time increase exponentially. This happens at DataScrubber.Scrub method, at Regex.Replace(). Modifying the regular expressions from "(--.*)" to "(--).*" solves the issue.