### PR TITLE
Use Schema and object name to identify objects

### DIFF
--- a/SQLCC.Core/Objects/DbCodeSegment.cs
+++ b/SQLCC.Core/Objects/DbCodeSegment.cs
@@ -2,6 +2,8 @@ namespace SQLCC.Core.Objects
 {
    public class DbCodeSegment
    {
+      public string SchemaName { get; set; }
+      
       public string ObjectName { get; set; }
       
       public int LinesOfCode { get; set; }

--- a/SQLCC.Impl.MsSqlProvider/MsSqlProvider.cs
+++ b/SQLCC.Impl.MsSqlProvider/MsSqlProvider.cs
@@ -116,10 +116,13 @@ exec sp_trace_setstatus @@TraceID, 2 -- delete");
       public override List<DbCodeSegment> GetTraceCodeSegments(string traceName)
       {
          var trace = Path.Combine(_traceDir, string.Format(TraceFileFormat, traceName));
-         var codeTrace = _db.Fetch<DbCodeSegment>(@"SELECT DISTINCT LineNumber, Offset as StartByte, IntegerData2 as EndByte, ObjectName
+         var codeTrace = _db.Fetch<DbCodeSegment>(@"SELECT	LineNumber, StartByte, EndByte, ObjectName, OBJECT_SCHEMA_NAME(ObjectID) SchemaName
+FROM (
+	SELECT DISTINCT LineNumber, Offset as StartByte, IntegerData2 as EndByte, ObjectName, ObjectID
 FROM ::fn_trace_gettable('" + trace + @"', default) 
-WHERE EventClass IN (40,41,42,43,44) AND Offset IS NOT NULL AND ObjectName IS NOT NULL
-ORDER BY ObjectName, LineNumber ASC, StartByte ASC, IntegerData2 ASC;");
+	WHERE EventClass IN (40,41,42,43,44) AND Offset IS NOT NULL AND ObjectName IS NOT NULL AND Offset <= IntegerData2
+	) cs
+ORDER BY SchemaName, ObjectName, LineNumber ASC, StartByte ASC, EndByte ASC;");
          return codeTrace;
       }
 

--- a/SQLCC/CodeCoverageProcessor.cs
+++ b/SQLCC/CodeCoverageProcessor.cs
@@ -89,7 +89,7 @@ namespace SQLCC
       {
          foreach (var obj in codeCover.TotalObjects)
          {
-            obj.CoveredSegments = codeCover.TraceCodeSegments.Where(p => p.ObjectName.Equals(obj.Name)).ToList();
+            obj.CoveredSegments = codeCover.TraceCodeSegments.Where(p => p.ObjectName.Equals(obj.Name) && p.SchemaName.Equals(obj.Schema)).ToList();
             obj.Set(ProcessObjectCoverage(obj));
             obj.CodeHighlighted = _highlightCodeProvider.HighlightCode(obj.Code, obj.CoveredSegments);
 


### PR DESCRIPTION
Objects with the same name in different schemas are misidentified.

SchemaName is added to the DbCodeSegment object

GetTraceCodeSegments is changed to use ObjectID to identify the object
schema.

ProcessAllCoverage is changed to identify code segments by ObjectName
and SchemaName.
